### PR TITLE
Enable GitHub Actions

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,0 +1,38 @@
+on:
+  push:
+    branches:
+      - master
+      - beta
+    pull_request:
+      branches:
+        - '**'
+
+name: python tests
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ['3.8']
+    name: python ${{ matrix.python-version }} - ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Initialize python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: install CI dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pylint mypy
+      - name: install SDK
+        run: python setup.py install
+      - name: lint - pylint
+        run: python -m pylint --disable==all $(git ls-files '*.py') || true
+      - name: lint - mypy
+        run: python -m mypy --strict $(git ls-files '*.py') || true
+      - name: unit tests
+        run: |
+          pip install -r tests/requirements.txt
+          pytest tests/rubrik_polaris

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,2 @@
+pytest
+requests_mock


### PR DESCRIPTION
Run linters and unit tests on linux, macOS and windows. Note that the
linters currently won't fail the pipeline since there are too many
issues. The intent is to require them to pass in the future when they
are configured and remaining issues are fixed.