### PR TITLE
Add script for Private Container Registries (PCR) on AWS

### DIFF
--- a/sample/k8s_onboarding/onboard.py
+++ b/sample/k8s_onboarding/onboard.py
@@ -125,8 +125,8 @@ def _kubectl_apply(ctx: str, url: str):
 
 
 @retry(stop=stop_after_delay(600),
-       wait=wait_exponential(multiplier=1, min=1, max=10),
-       reraise=True)
+        wait=wait_exponential(multiplier=1, min=1, max=10),
+        reraise=True)
 def _refresh_k8s_cluster(k8s_cluster_id: uuid.UUID):
     resp = rubrik.refresh_k8s_cluster(k8s_cluster_id, wait=True)
     if resp['status'] == 'FAILED':

--- a/sample/pcr-aws/README.MD
+++ b/sample/pcr-aws/README.MD
@@ -9,4 +9,7 @@ This script downloads the images that are used for Rubrik Security Cloud Exocomp
 1. Run `cd ../rubrik-polaris-sdk-for-python/sample/pcr-aws`
 1. Run `pip3 install -r requirements.txt` to install the AWS Python Module and Docker Python Module.
 1. [Create an RSC service account](https://docs.rubrik.com/en-us/saas/saas/adding_a_service_account.html) user and download the key file JSON file.
+1. [Install the Docker engine](https://docs.docker.com/engine/install/).
+1. Run `docker run hello-world` to verify that the Docker engine is working properly.
+1. Make sure that you have enough space on your local system to download the images. Images will be downloaded to the default local Docker registry.
 1. Run `python3 ./pcr.py --keyfile <path to keyfile> --pcrFqdn <FQDN_of_the_private_container_registry> --profile <Name_of_the_AWS_profile_with_the_private_container_registry>`

--- a/sample/pcr-aws/README.MD
+++ b/sample/pcr-aws/README.MD
@@ -1,0 +1,12 @@
+# Introduction
+
+This script downloads the images that are used for Rubrik Security Cloud Exocompute on AWS. It provides an example for scanning these images and then pushing them to a Private Container Registry.
+
+## Steps
+
+1. [Download](https://www.python.org/downloads/) and [install](https://docs.python.org/3/using/unix.html#getting-and-installing-the-latest-version-of-python) Python 3
+1. [Clone and install](https://github.com/rubrikinc/rubrik-polaris-sdk-for-python?tab=readme-ov-file#installation) the Rubrik Security Cloud Python SDK
+1. Run `cd ../rubrik-polaris-sdk-for-python/sample/pcr-aws`
+1. Run `pip3 install -r requirements.txt` to install the AWS Python Module and Docker Python Module.
+1. [Create an RSC service account](https://docs.rubrik.com/en-us/saas/saas/adding_a_service_account.html) user and download the key file JSON file.
+1. Run `python3 ./pcr.py --keyfile <path to keyfile>`

--- a/sample/pcr-aws/README.MD
+++ b/sample/pcr-aws/README.MD
@@ -9,4 +9,4 @@ This script downloads the images that are used for Rubrik Security Cloud Exocomp
 1. Run `cd ../rubrik-polaris-sdk-for-python/sample/pcr-aws`
 1. Run `pip3 install -r requirements.txt` to install the AWS Python Module and Docker Python Module.
 1. [Create an RSC service account](https://docs.rubrik.com/en-us/saas/saas/adding_a_service_account.html) user and download the key file JSON file.
-1. Run `python3 ./pcr.py --keyfile <path to keyfile>`
+1. Run `python3 ./pcr.py --keyfile <path to keyfile> --pcrFqdn <FQDN_of_the_private_container_registry> --profile <Name_of_the_AWS_profile_with_the_private_container_registry>`

--- a/sample/pcr-aws/pcr.py
+++ b/sample/pcr-aws/pcr.py
@@ -20,6 +20,7 @@ parser.add_argument('-u', '--username', dest='username', help="Polaris UserName"
 parser.add_argument('-d', '--domain', dest='domain', help="Polaris Domain", default=None)
 parser.add_argument('-k', '--keyfile', dest='json_keyfile', help="JSON Keyfile", default=None)
 parser.add_argument('-r', '--root', dest='root_domain', help="Polaris Root Domain", default=None)
+parser.add_argument('--profile', dest='profile', help="AWS Profile", default=None, required=True)
 parser.add_argument('--insecure', help='Deactivate SSL Verification', action="store_true")
 parser.add_argument('--pcrFqdn', dest='pcrFqdn', help='Private Container Registry URL', default=None, required=True)
 parser.add_argument('--debug', help="Print lots of debugging statements", action="store_const", dest="loglevel", const=logging.DEBUG, default=logging.WARNING)
@@ -49,7 +50,8 @@ except Exception as err:
 
 # Login to AWS ECR
 
-rscEcrClient = boto3.client('ecr', region_name="us-east-1")
+rscEcrSession = boto3.Session(profile_name=args.profile)
+rscEcrClient = rscEcrSession.client('ecr', region_name="us-east-1")
 
 # Setup Docker client
 
@@ -162,8 +164,8 @@ for bundleImages in exoTaskImageBundle['data']['exotaskImageBundle']['bundleImag
 print("")
 
 #Login to customer PCR
-
-customerEcrClient = boto3.client('ecr', region_name=pcrRegion)
+customerEcrSession = boto3.Session(profile_name=args.profile)
+customerEcrClient = customerEcrSession.client('ecr', region_name=pcrRegion)
 # Get customer PCR token
 # CLI Example "aws ecr get-authorization-token --region <customer_ecr_region>"
 try:

--- a/sample/pcr-aws/pcr.py
+++ b/sample/pcr-aws/pcr.py
@@ -1,0 +1,252 @@
+#! /usr/bin/env python3
+import argparse, base64, boto3, docker, json, logging, os, pprint, subprocess, sys
+from rubrik_polaris.rubrik_polaris import PolarisClient
+
+pp = pprint.PrettyPrinter(indent=2)
+#logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
+
+parser = argparse.ArgumentParser()
+parser.add_argument('-p', '--password', dest='password', help="Polaris Password", default=None)
+parser.add_argument('-u', '--username', dest='username', help="Polaris UserName", default=None)
+parser.add_argument('-d', '--domain', dest='domain', help="Polaris Domain", default=None)
+parser.add_argument('-k', '--keyfile', dest='json_keyfile', help="JSON Keyfile", default=None)
+parser.add_argument('-r', '--root', dest='root_domain', help="Polaris Root Domain", default=None)
+parser.add_argument('--insecure', help='Deactivate SSL Verification', action="store_true")
+parser.add_argument('--pcrFqdn', dest='pcrFqdn', help='Private Container Registry URL', default=None, required=True)
+parser.add_argument('--debug', help="Print lots of debugging statements", action="store_const", dest="loglevel", const=logging.DEBUG, default=logging.WARNING)
+parser.add_argument('-v', '--verbose', help="Be verbose", action="store_const", dest="loglevel", const=logging.INFO)
+
+args = parser.parse_args()
+pcrFqdn = args.pcrFqdn
+
+logging.basicConfig(level=args.loglevel)
+
+if not (args.json_keyfile or (args.username and args.password and args.domain)):
+    parser.error('Login credentials not specified. You must specify either a JSON keyfile or a username, password, and domain.')
+
+try:
+
+### Instantiate with json keyfile
+    if args.json_keyfile:
+        rubrik = PolarisClient(json_keyfile=args.json_keyfile, insecure=args.insecure)
+    else:
+### Instantiate with username/password
+        rubrik = PolarisClient(domain=args.domain, username=args.username, password=args.password, root_domain=args.root_domain,
+                                      insecure=args.insecure)
+        
+except Exception as err:
+    print(err)
+    sys.exit(1)
+
+# Login to AWS ECR
+
+rscEcrClient = boto3.client('ecr', region_name="us-east-1")
+
+# Setup Docker client
+
+dockerClient = docker.from_env()
+docker_api_client = docker.APIClient(base_url='unix://var/run/docker.sock') 
+
+# Get Exocompute Bundle (containers)
+
+try:
+    exoTaskImageBundle = rubrik._query_raw(raw_query='query ExotaskImageBundle { exotaskImageBundle {bundleVersion repoUrl bundleImages {name tag sha}}}',
+                                      operation_name=None,
+                                      variables={},
+                                      timeout=60)
+except Exception as err:
+    print("Error: Unable to retrieve exotaskImageBundle")
+    print(err)
+    sys.exit(1)
+
+logging.debug("")
+logging.debug(json.dumps(exoTaskImageBundle, indent=2))
+logging.debug("")
+
+region = exoTaskImageBundle['data']['exotaskImageBundle']['repoUrl'].split('.')[3]
+print("")
+print("Region: " + region)
+rscRepoFqdn = exoTaskImageBundle['data']['exotaskImageBundle']['repoUrl']
+print ("Repo URL: " + rscRepoFqdn)
+pcrRegion= args.pcrFqdn.split('.')[3]
+print("PCR Region: " + pcrRegion)
+print("")
+
+# Login to RSC ECR
+# Requires that the RSC setPrivateContainerRegistry GraphQL mutation has been run to set the registry URL in RSC.
+# This step would have been done as part of the RSC setup process.
+
+# CLI example: "aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin <Rubrik_ECR_AWS_Account_ID>.dkr.ecr.us-east-1.amazonaws.com")
+
+try:
+    rscEcrToken = rscEcrClient.get_authorization_token(registryIds=[rscRepoFqdn.split('.')[0]])
+except Exception as err: 
+    print("Error: Unable to get RSC ECR token.")
+    print(err)
+    sys.exit(1)
+
+logging.info("rscEcrToken: %s", rscEcrToken)
+
+try:
+    username, password = base64.b64decode(rscEcrToken['authorizationData'][0]['authorizationToken']).decode('utf-8').split(":")
+    rsc_auth_config_payload = { 'username': username, 'password': password }
+    rscEcr = dockerClient.login(username=username, password=password, registry=rscEcrToken['authorizationData'][0]['proxyEndpoint'].replace("https://", ""), reauth=True)
+except Exception as err:
+    print("Error: Unable to login to RSC ECR")
+    print(err)
+    sys.exit(1)
+
+# Pull images into local repository
+for bundleImages in exoTaskImageBundle['data']['exotaskImageBundle']['bundleImages']:
+    logging.info("rsc_auth_config_payload: %s", rsc_auth_config_payload)
+    if bundleImages['tag']:
+#       CLI example: "docker pull <Rubrik_ECR_AWS_Account_ID>.dkr.ecr.us-east-1.amazonaws.com/<build_image_name>:<tag>"
+        print("Pulling " + bundleImages['name'] + " with tag " + bundleImages['tag'])
+        try:
+          #response = dockerClient.images.pull(rscRepoFqdn + '/' + bundleImages['name'], tag=bundleImages['tag'])
+          for line in docker_api_client.pull(rscRepoFqdn + '/' + bundleImages['name'], tag=bundleImages['tag'], stream=True, auth_config=rsc_auth_config_payload, decode=True):
+            print(line)
+            logging.info(json.dumps(line, indent=2))
+
+        except Exception as err:
+          print("Error: Image pull failed for " + bundleImages['name'] + " with tag " + bundleImages['tag'])
+          print(err)
+          sys.exit(1)
+    elif bundleImages['sha']:
+#       CLI example: "docker pull <Rubrik_ECR_AWS_Account_ID>.dkr.ecr.us-east-1.amazonaws.com/<build_image_name>@sha256:<sha>"
+        print("Pulling " + bundleImages['name'] + " with sha " + bundleImages['sha'])
+        try:
+          #response = dockerClient.images.pull(rscRepoFqdn + '/' + bundleImages['name'], tag="sha256:" + bundleImages['sha'])
+          for line in docker_api_client.pull(rscRepoFqdn + '/' + bundleImages['name'], tag="sha256:" + bundleImages['sha'], stream=True, auth_config=rsc_auth_config_payload, decode=True):
+            print(line)
+            logging.info(json.dumps(line, indent=2))
+        except Exception as err:
+          print("Error: Image pull failed for " + bundleImages['name'] + " with sha " + bundleImages['sha'])
+          print(err)
+          sys.exit(1)
+    else:
+        print("Error: No tag or sha found for " + bundleImages['name'] + " in " + rscRepoFqdn + " bundle.")
+        sys.exit(1)
+
+# Scan images for vulnerabilities
+print("")
+print("Scanning images for vulnerabilities")
+
+for bundleImages in exoTaskImageBundle['data']['exotaskImageBundle']['bundleImages']:
+    if bundleImages['tag']:
+        print("Scanning " + bundleImages['name'] + " with tag " + bundleImages['tag'])
+        try:
+          print("<Insert Image Scanning Tool Here>")
+        except Exception as err:
+          print("Error: Image scanning failed for " + bundleImages['name'] + " with tag " + bundleImages['tag'])
+          print(err)
+          sys.exit(1)
+    elif bundleImages['sha']:
+        print("Scanning " + bundleImages['name'] + " with sha " + bundleImages['sha'])
+        try:
+          print("<Insert Image Scanning Tool Here>")
+        except Exception as err:
+          print("Error: Image scanning failed for " + bundleImages['name'] + " with sha " + bundleImages['sha'])
+          print(err)
+          sys.exit(1)
+    else:
+        print("Error: No tag or sha found for " + bundleImages['name'] + " in " + rscRepoFqdn + " bundle.")
+        sys.exit(1)
+print("")
+
+#Login to customer PCR
+
+customerEcrClient = boto3.client('ecr', region_name=pcrRegion)
+# Get customer PCR token
+# CLI Example "aws ecr get-authorization-token --region <customer_ecr_region>"
+try:
+      customerEcrToken = customerEcrClient.get_authorization_token(registryIds=[pcrFqdn.split('.')[0]])
+except Exception as err:
+    print("Error: Unable to get customer PCR token.")
+    print(err)
+    sys.exit(1)
+
+# CLI Example "aws ecr get-login-password --region <customer_ecr_region> | docker login --username AWS --password-stdin <customer_pcr_url>"
+try:
+    username, password = base64.b64decode(customerEcrToken['authorizationData'][0]['authorizationToken']).decode('utf-8').split(":")
+    customer_auth_config_payload = { 'username': username, 'password': password }
+    customerEcr = dockerClient.login(username=username, password=password, registry=customerEcrToken['authorizationData'][0]['proxyEndpoint'].replace("https://", ""), reauth=True)
+except Exception as err:    
+    print("Error: Unable to login to customer PCR")
+    print(err)
+    sys.exit(1)
+
+# Create Repos, Tag and push images to customer PCR
+
+# Determine if repository exists and create if it does not.
+# CLI example: "aws ecr describe-repositories --region <customer_ecr_region>"
+
+pcrRepositories = customerEcrClient.describe_repositories()
+for bundleImages in exoTaskImageBundle['data']['exotaskImageBundle']['bundleImages']:
+    print("")
+    repoExists = False
+    for repo in pcrRepositories['repositories']:
+        if repo['repositoryName'] == bundleImages['name']:
+            print("Repository " + bundleImages['name'] + " already exists in " + pcrFqdn + ". Skipping create" )
+            repoExists = True
+            break
+# If repo does not exist, create it.
+    if not repoExists:
+        # CLI example: "aws ecr create-repository --repository-name <build_image_name> --region <customer_ecr_region> --image-scanning-configuration scanOnPush=true --encryption-configuration encryptionType=AES256 --image-tag-mutability IMMUTABLE"
+        print("Creating repository " + bundleImages['name'] + " in " + pcrFqdn)
+        customerEcrClient.create_repository(repositoryName=bundleImages['name'],
+                                    imageScanningConfiguration={'scanOnPush': True},
+                                    encryptionConfiguration={'encryptionType': 'AES256'},
+                                    imageTagMutability='IMMUTABLE')
+
+    if bundleImages['tag']:
+        print("Tagging and pushing " + bundleImages['name'] + " with tag " + bundleImages['tag'])
+        # CLI Example "docker image tag <Rubrik_ECR_AWS_Account_ID>.dkr.ecr.us-east-1.amazonaws.com/<build_image_name>:<tag><customer_pcr_url>/<build_image_name>:<tag>"
+        try:
+          docker_api_client.tag(rscRepoFqdn + '/' + bundleImages['name'] + ":" + bundleImages['tag'], pcrFqdn + '/' + bundleImages['name'] + ":" + bundleImages['tag'])
+        except Exception as err:
+          print("Error: Image tag failed for " + bundleImages['name'] + " with tag " + bundleImages['tag'])
+          print(err)
+          sys.exit(1)
+        print("Pushing " + bundleImages['name'] + " with tag " + bundleImages['tag'])
+        # CLI Example "docker push <customer_pcr_url>/<build_image_name>:<tag>"
+        try:
+          for line in docker_api_client.push(pcrFqdn + '/' + bundleImages['name'], tag=bundleImages['tag'], stream=True, auth_config=customer_auth_config_payload, decode=True):
+            print(line)
+            logging.info(json.dumps(line, indent=2))
+        except Exception as err:
+          print("Error: Image push failed for " + bundleImages['name'] + " with tag " + bundleImages['tag'])
+          print(err)
+          sys.exit(1)
+    elif bundleImages['sha']:
+        print("Tagging and pushing " + bundleImages['name'] + " with sha " + bundleImages['sha'])
+        # CLI Example "docker image tag <Rubrik_ECR_AWS_Account_ID>.dkr.ecr.us-east-1.amazonaws.com/<build_image_name>@sha256:<sha> <customer_pcr_url>/<build_image_name>"       
+        try:
+          docker_api_client.tag(rscRepoFqdn + '/' + bundleImages['name'] + "@sha256:" + bundleImages['sha'], pcrFqdn + '/' + bundleImages['name'] )
+        except Exception as err:
+          print("Error: Image tag failed for " + bundleImages['name'] + " with sha " + bundleImages['sha'])
+          print(err)
+          sys.exit(1)
+        print("Pushing " + bundleImages['name'] + " with sha " + bundleImages['sha'])
+        # CLI Example "docker push <customer_pcr_url>/<build_image_name>@sha256:<sha>"
+        try:
+          for line in docker_api_client.push(pcrFqdn + '/' + bundleImages['name'], stream=True, auth_config=customer_auth_config_payload, decode=True):
+              print(line)
+              logging.info(json.dumps(line, indent=2))
+        except Exception as err:
+          print("Error: Image push failed for " + bundleImages['name'] + " with sha " + bundleImages['sha'])
+          print(err)
+          sys.exit(1) 
+        
+#Accept Container Bundle
+variables = {
+  "input": {
+    "approvalStatus": "ACCEPTED",
+    "bundleVersion": "{}".format(exoTaskImageBundle['data']['exotaskImageBundle']['bundleVersion'])
+  }
+}
+exoTaskImageBundle = rubrik._query_raw(raw_query='mutation SetBundleApprovalStatus($input: SetBundleApprovalStatusInput!) {setBundleApprovalStatus(input: $input)}', 
+                                      operation_name=None, 
+#                                      variables={'"input": {"approvalStatus": "ACCEPTED","bundleVersion": {}}'.format(exoTaskImageBundle['data']['exotaskImageBundle']['bundleVersion'])},
+                                      variables=variables,
+                                      timeout=60)

--- a/sample/pcr-aws/pcr.py
+++ b/sample/pcr-aws/pcr.py
@@ -1,5 +1,14 @@
 #! /usr/bin/env python3
-import argparse, base64, boto3, docker, json, logging, os, pprint, subprocess, sys
+import argparse
+import base64
+import boto3
+import docker
+import json
+import logging
+import os
+import pprint
+import subprocess
+import sys
 from rubrik_polaris.rubrik_polaris import PolarisClient
 
 pp = pprint.PrettyPrinter(indent=2)
@@ -33,7 +42,7 @@ try:
 ### Instantiate with username/password
         rubrik = PolarisClient(domain=args.domain, username=args.username, password=args.password, root_domain=args.root_domain,
                                       insecure=args.insecure)
-        
+
 except Exception as err:
     print(err)
     sys.exit(1)
@@ -45,7 +54,7 @@ rscEcrClient = boto3.client('ecr', region_name="us-east-1")
 # Setup Docker client
 
 dockerClient = docker.from_env()
-docker_api_client = docker.APIClient(base_url='unix://var/run/docker.sock') 
+docker_api_client = docker.APIClient(base_url='unix://var/run/docker.sock')
 
 # Get Exocompute Bundle (containers)
 
@@ -80,7 +89,7 @@ print("")
 
 try:
     rscEcrToken = rscEcrClient.get_authorization_token(registryIds=[rscRepoFqdn.split('.')[0]])
-except Exception as err: 
+except Exception as err:
     print("Error: Unable to get RSC ECR token.")
     print(err)
     sys.exit(1)
@@ -103,27 +112,25 @@ for bundleImages in exoTaskImageBundle['data']['exotaskImageBundle']['bundleImag
 #       CLI example: "docker pull <Rubrik_ECR_AWS_Account_ID>.dkr.ecr.us-east-1.amazonaws.com/<build_image_name>:<tag>"
         print("Pulling " + bundleImages['name'] + " with tag " + bundleImages['tag'])
         try:
-          #response = dockerClient.images.pull(rscRepoFqdn + '/' + bundleImages['name'], tag=bundleImages['tag'])
-          for line in docker_api_client.pull(rscRepoFqdn + '/' + bundleImages['name'], tag=bundleImages['tag'], stream=True, auth_config=rsc_auth_config_payload, decode=True):
-            print(line)
-            logging.info(json.dumps(line, indent=2))
+            for line in docker_api_client.pull(rscRepoFqdn + '/' + bundleImages['name'], tag=bundleImages['tag'], stream=True, auth_config=rsc_auth_config_payload, decode=True):
+                print(line)
+                logging.info(json.dumps(line, indent=2))
 
         except Exception as err:
-          print("Error: Image pull failed for " + bundleImages['name'] + " with tag " + bundleImages['tag'])
-          print(err)
-          sys.exit(1)
+            print("Error: Image pull failed for " + bundleImages['name'] + " with tag " + bundleImages['tag'])
+            print(err)
+            sys.exit(1)
     elif bundleImages['sha']:
 #       CLI example: "docker pull <Rubrik_ECR_AWS_Account_ID>.dkr.ecr.us-east-1.amazonaws.com/<build_image_name>@sha256:<sha>"
         print("Pulling " + bundleImages['name'] + " with sha " + bundleImages['sha'])
         try:
-          #response = dockerClient.images.pull(rscRepoFqdn + '/' + bundleImages['name'], tag="sha256:" + bundleImages['sha'])
-          for line in docker_api_client.pull(rscRepoFqdn + '/' + bundleImages['name'], tag="sha256:" + bundleImages['sha'], stream=True, auth_config=rsc_auth_config_payload, decode=True):
-            print(line)
-            logging.info(json.dumps(line, indent=2))
+            for line in docker_api_client.pull(rscRepoFqdn + '/' + bundleImages['name'], tag="sha256:" + bundleImages['sha'], stream=True, auth_config=rsc_auth_config_payload, decode=True):
+                print(line)
+                logging.info(json.dumps(line, indent=2))
         except Exception as err:
-          print("Error: Image pull failed for " + bundleImages['name'] + " with sha " + bundleImages['sha'])
-          print(err)
-          sys.exit(1)
+            print("Error: Image pull failed for " + bundleImages['name'] + " with sha " + bundleImages['sha'])
+            print(err)
+            sys.exit(1)
     else:
         print("Error: No tag or sha found for " + bundleImages['name'] + " in " + rscRepoFqdn + " bundle.")
         sys.exit(1)
@@ -136,19 +143,19 @@ for bundleImages in exoTaskImageBundle['data']['exotaskImageBundle']['bundleImag
     if bundleImages['tag']:
         print("Scanning " + bundleImages['name'] + " with tag " + bundleImages['tag'])
         try:
-          print("<Insert Image Scanning Tool Here>")
+            print("<Insert Image Scanning Tool Here>")
         except Exception as err:
-          print("Error: Image scanning failed for " + bundleImages['name'] + " with tag " + bundleImages['tag'])
-          print(err)
-          sys.exit(1)
+            print("Error: Image scanning failed for " + bundleImages['name'] + " with tag " + bundleImages['tag'])
+            print(err)
+            sys.exit(1)
     elif bundleImages['sha']:
         print("Scanning " + bundleImages['name'] + " with sha " + bundleImages['sha'])
         try:
-          print("<Insert Image Scanning Tool Here>")
+            print("<Insert Image Scanning Tool Here>")
         except Exception as err:
-          print("Error: Image scanning failed for " + bundleImages['name'] + " with sha " + bundleImages['sha'])
-          print(err)
-          sys.exit(1)
+            print("Error: Image scanning failed for " + bundleImages['name'] + " with sha " + bundleImages['sha'])
+            print(err)
+            sys.exit(1)
     else:
         print("Error: No tag or sha found for " + bundleImages['name'] + " in " + rscRepoFqdn + " bundle.")
         sys.exit(1)
@@ -160,7 +167,7 @@ customerEcrClient = boto3.client('ecr', region_name=pcrRegion)
 # Get customer PCR token
 # CLI Example "aws ecr get-authorization-token --region <customer_ecr_region>"
 try:
-      customerEcrToken = customerEcrClient.get_authorization_token(registryIds=[pcrFqdn.split('.')[0]])
+    customerEcrToken = customerEcrClient.get_authorization_token(registryIds=[pcrFqdn.split('.')[0]])
 except Exception as err:
     print("Error: Unable to get customer PCR token.")
     print(err)
@@ -171,7 +178,7 @@ try:
     username, password = base64.b64decode(customerEcrToken['authorizationData'][0]['authorizationToken']).decode('utf-8').split(":")
     customer_auth_config_payload = { 'username': username, 'password': password }
     customerEcr = dockerClient.login(username=username, password=password, registry=customerEcrToken['authorizationData'][0]['proxyEndpoint'].replace("https://", ""), reauth=True)
-except Exception as err:    
+except Exception as err:
     print("Error: Unable to login to customer PCR")
     print(err)
     sys.exit(1)
@@ -203,41 +210,41 @@ for bundleImages in exoTaskImageBundle['data']['exotaskImageBundle']['bundleImag
         print("Tagging and pushing " + bundleImages['name'] + " with tag " + bundleImages['tag'])
         # CLI Example "docker image tag <Rubrik_ECR_AWS_Account_ID>.dkr.ecr.us-east-1.amazonaws.com/<build_image_name>:<tag><customer_pcr_url>/<build_image_name>:<tag>"
         try:
-          docker_api_client.tag(rscRepoFqdn + '/' + bundleImages['name'] + ":" + bundleImages['tag'], pcrFqdn + '/' + bundleImages['name'] + ":" + bundleImages['tag'])
+            docker_api_client.tag(rscRepoFqdn + '/' + bundleImages['name'] + ":" + bundleImages['tag'], pcrFqdn + '/' + bundleImages['name'] + ":" + bundleImages['tag'])
         except Exception as err:
-          print("Error: Image tag failed for " + bundleImages['name'] + " with tag " + bundleImages['tag'])
-          print(err)
-          sys.exit(1)
+            print("Error: Image tag failed for " + bundleImages['name'] + " with tag " + bundleImages['tag'])
+            print(err)
+            sys.exit(1)
         print("Pushing " + bundleImages['name'] + " with tag " + bundleImages['tag'])
         # CLI Example "docker push <customer_pcr_url>/<build_image_name>:<tag>"
         try:
-          for line in docker_api_client.push(pcrFqdn + '/' + bundleImages['name'], tag=bundleImages['tag'], stream=True, auth_config=customer_auth_config_payload, decode=True):
-            print(line)
-            logging.info(json.dumps(line, indent=2))
+            for line in docker_api_client.push(pcrFqdn + '/' + bundleImages['name'], tag=bundleImages['tag'], stream=True, auth_config=customer_auth_config_payload, decode=True):
+                print(line)
+                logging.info(json.dumps(line, indent=2))
         except Exception as err:
-          print("Error: Image push failed for " + bundleImages['name'] + " with tag " + bundleImages['tag'])
-          print(err)
-          sys.exit(1)
+            print("Error: Image push failed for " + bundleImages['name'] + " with tag " + bundleImages['tag'])
+            print(err)
+            sys.exit(1)
     elif bundleImages['sha']:
         print("Tagging and pushing " + bundleImages['name'] + " with sha " + bundleImages['sha'])
-        # CLI Example "docker image tag <Rubrik_ECR_AWS_Account_ID>.dkr.ecr.us-east-1.amazonaws.com/<build_image_name>@sha256:<sha> <customer_pcr_url>/<build_image_name>"       
+        # CLI Example "docker image tag <Rubrik_ECR_AWS_Account_ID>.dkr.ecr.us-east-1.amazonaws.com/<build_image_name>@sha256:<sha> <customer_pcr_url>/<build_image_name>"
         try:
-          docker_api_client.tag(rscRepoFqdn + '/' + bundleImages['name'] + "@sha256:" + bundleImages['sha'], pcrFqdn + '/' + bundleImages['name'] )
+            docker_api_client.tag(rscRepoFqdn + '/' + bundleImages['name'] + "@sha256:" + bundleImages['sha'], pcrFqdn + '/' + bundleImages['name'] )
         except Exception as err:
-          print("Error: Image tag failed for " + bundleImages['name'] + " with sha " + bundleImages['sha'])
-          print(err)
-          sys.exit(1)
+            print("Error: Image tag failed for " + bundleImages['name'] + " with sha " + bundleImages['sha'])
+            print(err)
+            sys.exit(1)
         print("Pushing " + bundleImages['name'] + " with sha " + bundleImages['sha'])
         # CLI Example "docker push <customer_pcr_url>/<build_image_name>@sha256:<sha>"
         try:
-          for line in docker_api_client.push(pcrFqdn + '/' + bundleImages['name'], stream=True, auth_config=customer_auth_config_payload, decode=True):
-              print(line)
-              logging.info(json.dumps(line, indent=2))
+            for line in docker_api_client.push(pcrFqdn + '/' + bundleImages['name'], stream=True, auth_config=customer_auth_config_payload, decode=True):
+                print(line)
+                logging.info(json.dumps(line, indent=2))
         except Exception as err:
-          print("Error: Image push failed for " + bundleImages['name'] + " with sha " + bundleImages['sha'])
-          print(err)
-          sys.exit(1) 
-        
+            print("Error: Image push failed for " + bundleImages['name'] + " with sha " + bundleImages['sha'])
+            print(err)
+            sys.exit(1)
+
 #Accept Container Bundle
 variables = {
   "input": {
@@ -245,8 +252,8 @@ variables = {
     "bundleVersion": "{}".format(exoTaskImageBundle['data']['exotaskImageBundle']['bundleVersion'])
   }
 }
-exoTaskImageBundle = rubrik._query_raw(raw_query='mutation SetBundleApprovalStatus($input: SetBundleApprovalStatusInput!) {setBundleApprovalStatus(input: $input)}', 
-                                      operation_name=None, 
+exoTaskImageBundle = rubrik._query_raw(raw_query='mutation SetBundleApprovalStatus($input: SetBundleApprovalStatusInput!) {setBundleApprovalStatus(input: $input)}',
+                                      operation_name=None,
 #                                      variables={'"input": {"approvalStatus": "ACCEPTED","bundleVersion": {}}'.format(exoTaskImageBundle['data']['exotaskImageBundle']['bundleVersion'])},
                                       variables=variables,
                                       timeout=60)

--- a/sample/pcr-aws/pcr.py
+++ b/sample/pcr-aws/pcr.py
@@ -209,37 +209,37 @@ for bundleImages in exoTaskImageBundle['data']['exotaskImageBundle']['bundleImag
                                     imageTagMutability='IMMUTABLE')
 
     if bundleImages['tag']:
-        print("Tagging and pushing " + bundleImages['name'] + " with tag " + bundleImages['tag'])
-        # CLI Example "docker image tag <Rubrik_ECR_AWS_Account_ID>.dkr.ecr.us-east-1.amazonaws.com/<build_image_name>:<tag><customer_pcr_url>/<build_image_name>:<tag>"
+        print("Tagging and pushing " + bundleImages['name'] + " with tag " + bundleImages['tag'] + " to " + bundleImages['name'] + " with version tag " + exoTaskImageBundle['data']['exotaskImageBundle']['bundleVersion'])
+        # CLI Example "docker image tag <Rubrik_ECR_AWS_Account_ID>.dkr.ecr.us-east-1.amazonaws.com/<build_image_name>:<tag><customer_pcr_url>/<build_image_name>:<bundle_version>"
         try:
-            docker_api_client.tag(rscRepoFqdn + '/' + bundleImages['name'] + ":" + bundleImages['tag'], pcrFqdn + '/' + bundleImages['name'] + ":" + bundleImages['tag'])
+            docker_api_client.tag(rscRepoFqdn + '/' + bundleImages['name'] + ":" + bundleImages['tag'], pcrFqdn + '/' + bundleImages['name'] + ":" + exoTaskImageBundle['data']['exotaskImageBundle']['bundleVersion'])
         except Exception as err:
             print("Error: Image tag failed for " + bundleImages['name'] + " with tag " + bundleImages['tag'])
             print(err)
             sys.exit(1)
         print("Pushing " + bundleImages['name'] + " with tag " + bundleImages['tag'])
-        # CLI Example "docker push <customer_pcr_url>/<build_image_name>:<tag>"
+        # CLI Example "docker push <customer_pcr_url>/<build_image_name>:<bundle_version>"
         try:
-            for line in docker_api_client.push(pcrFqdn + '/' + bundleImages['name'], tag=bundleImages['tag'], stream=True, auth_config=customer_auth_config_payload, decode=True):
+            for line in docker_api_client.push(pcrFqdn + '/' + bundleImages['name'], tag=exoTaskImageBundle['data']['exotaskImageBundle']['bundleVersion'], stream=True, auth_config=customer_auth_config_payload, decode=True):
                 print(line)
                 logging.info(json.dumps(line, indent=2))
         except Exception as err:
-            print("Error: Image push failed for " + bundleImages['name'] + " with tag " + bundleImages['tag'])
+            print("Error: Image push failed for " + bundleImages['name'] + " with tag " + exoTaskImageBundle['data']['exotaskImageBundle']['bundleVersion'])
             print(err)
             sys.exit(1)
     elif bundleImages['sha']:
-        print("Tagging and pushing " + bundleImages['name'] + " with sha " + bundleImages['sha'])
-        # CLI Example "docker image tag <Rubrik_ECR_AWS_Account_ID>.dkr.ecr.us-east-1.amazonaws.com/<build_image_name>@sha256:<sha> <customer_pcr_url>/<build_image_name>"
+        print("Tagging and pushing " + bundleImages['name'] + " with sha " + bundleImages['sha'] + " to " + bundleImages['name'] + " with version tag " + exoTaskImageBundle['data']['exotaskImageBundle']['bundleVersion'])
+        # CLI Example "docker image tag <Rubrik_ECR_AWS_Account_ID>.dkr.ecr.us-east-1.amazonaws.com/<build_image_name>@sha256:<sha> <customer_pcr_url>/<build_image_name>:<bundle_version>"
         try:
-            docker_api_client.tag(rscRepoFqdn + '/' + bundleImages['name'] + "@sha256:" + bundleImages['sha'], pcrFqdn + '/' + bundleImages['name'] )
+            docker_api_client.tag(rscRepoFqdn + '/' + bundleImages['name'] + "@sha256:" + bundleImages['sha'], pcrFqdn + '/' + bundleImages['name'] +  ":" + exoTaskImageBundle['data']['exotaskImageBundle']['bundleVersion'])
         except Exception as err:
             print("Error: Image tag failed for " + bundleImages['name'] + " with sha " + bundleImages['sha'])
             print(err)
             sys.exit(1)
         print("Pushing " + bundleImages['name'] + " with sha " + bundleImages['sha'])
-        # CLI Example "docker push <customer_pcr_url>/<build_image_name>@sha256:<sha>"
+        # CLI Example "docker push <customer_pcr_url>/<build_image_name>:<bundle_version>"
         try:
-            for line in docker_api_client.push(pcrFqdn + '/' + bundleImages['name'], stream=True, auth_config=customer_auth_config_payload, decode=True):
+            for line in docker_api_client.push(pcrFqdn + '/' + bundleImages['name'], tag=exoTaskImageBundle['data']['exotaskImageBundle']['bundleVersion'], stream=True, auth_config=customer_auth_config_payload, decode=True):
                 print(line)
                 logging.info(json.dumps(line, indent=2))
         except Exception as err:

--- a/sample/pcr-aws/requirements.txt
+++ b/sample/pcr-aws/requirements.txt
@@ -1,3 +1,2 @@
 docker==7.0.0
 boto3==1.34.39
-Rubrik-Polaris-SDK-for-Python==2023.1.1

--- a/sample/pcr-aws/requirements.txt
+++ b/sample/pcr-aws/requirements.txt
@@ -1,0 +1,3 @@
+docker==7.0.0
+boto3==1.34.39
+Rubrik-Polaris-SDK-for-Python==2023.1.1


### PR DESCRIPTION
Added a new script for CNP to pull images from Rubrik's container registry and push them to a customer's Private Container Registry (PCR).

 Added minor fixes.