### PR TITLE
Fix for get_event_series_list and sample app for it

### DIFF
--- a/rubrik_polaris/common/core.py
+++ b/rubrik_polaris/common/core.py
@@ -290,11 +290,9 @@ def get_event_series_list(self, object_type=[], status=[], activity_type=[], sev
                 "lastActivityStatus": status,
                 "lastActivityType": activity_type,
                 "severity": severity,
-                "cluster": {
-                    "id": cluster_ids,
-                },
-                "lastUpdated_gt": start_time,
-                "lastUpdated_lt": end_time,
+                "clusterId": cluster_ids,
+                "lastUpdatedTimeGt": start_time,
+                "lastUpdatedTimeLt": end_time,
                 "objectName": ""
             }
         }

--- a/rubrik_polaris/common/core.py
+++ b/rubrik_polaris/common/core.py
@@ -264,7 +264,9 @@ def get_snapshots(self, snappable_id=None, recovery_point=None):
         raise
 
 
-def get_event_series_list(self, object_type=[], status=[], activity_type=[], severity=[], cluster_ids=[], start_time=None, end_time = None):
+def get_event_series_list(self, object_type=[], status=[], activity_type=[],
+                          severity=[], cluster_ids=[], start_time=None,
+                          end_time=None):
     """Retrieve Events from Polaris
 
     Args:
@@ -273,8 +275,8 @@ def get_event_series_list(self, object_type=[], status=[], activity_type=[], sev
         activity_type (list): List of Activity Types
         severity (list): List of severities
         cluster_ids (list): List of Cluster IDs (UUID)
-        start_date (datetime): Timestamp to start return set from
-        end_date (datetime): Timestamp to end return set from
+        start_time (datetime): Timestamp to start return set from
+        end_time (datetime): Timestamp to end return set from
 
     Returns:
         list: A list of dictionaries of Event Data

--- a/rubrik_polaris/common/core.py
+++ b/rubrik_polaris/common/core.py
@@ -275,8 +275,10 @@ def get_event_series_list(self, object_type=[], status=[], activity_type=[],
         activity_type (list): List of Activity Types
         severity (list): List of severities
         cluster_ids (list): List of Cluster IDs (UUID)
-        start_time (datetime): Timestamp to start return set from
-        end_time (datetime): Timestamp to end return set from
+        start_time (datetime): Filter in all events created or updated
+                               after this datetime
+        end_time (datetime): Filter in all events created or updated
+                             before this datetime
 
     Returns:
         list: A list of dictionaries of Event Data

--- a/sample/polaris_client.py
+++ b/sample/polaris_client.py
@@ -4,32 +4,37 @@ import pprint
 import sys
 from rubrik_polaris.rubrik_polaris import PolarisClient
 
-
 pp = pprint.PrettyPrinter(indent=4)
 
-parser = argparse.ArgumentParser()
-parser.add_argument('-p', '--password', dest='password', help="Polaris Password", default=None)
-parser.add_argument('-u', '--username', dest='username', help="Polaris UserName", default=None)
-parser.add_argument('-d', '--domain', dest='domain', help="Polaris Domain", default=None)
-parser.add_argument('-k', '--keyfile', dest='json_keyfile', help="JSON Keyfile", default=None)
-parser.add_argument('-r', '--root', dest='root_domain', help="Polaris Root Domain", default=None)
-parser.add_argument('--insecure', help='Deactivate SSL Verification', action="store_true")
+def build_arg_parser():
+    """Parse command-line arguments for Polaris client."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-p', '--password', dest='password', help="Polaris Password", default=None)
+    parser.add_argument('-u', '--username', dest='username', help="Polaris UserName", default=None)
+    parser.add_argument('-d', '--domain', dest='domain', help="Polaris Domain", default=None)
+    parser.add_argument('-k', '--keyfile', dest='json_keyfile', help="JSON Keyfile", default=None)
+    parser.add_argument('-r', '--root', dest='root_domain', help="Polaris Root Domain", default=None)
+    parser.add_argument('--insecure', help='Deactivate SSL Verification', action="store_true")
 
-args = parser.parse_args()
+    return parser
 
-try:
+def create_polaris_client(args):
+    """Create and return a PolarisClient based on provided arguments."""
+    try:
+        if args.json_keyfile:
+            rubrik = PolarisClient(json_keyfile=args.json_keyfile, insecure=args.insecure)
+        else:
+            rubrik = PolarisClient(domain=args.domain, username=args.username, password=args.password,
+                                   root_domain=args.root_domain, insecure=args.insecure)
+        return rubrik
 
-### Instantiate with json keyfile
-    if args.json_keyfile:
-        rubrik = PolarisClient(json_keyfile=args.json_keyfile, insecure=args.insecure)
-    else:
-### Instantiate with username/password
-        rubrik = PolarisClient(domain=args.domain, username=args.username, password=args.password, root_domain=args.root_domain,
-                                       insecure=args.insecure)
+    except Exception as err:
+        print(f"Error creating PolarisClient: {err}")
+        sys.exit(1)
 
-except Exception as err:
-    print(err)
-    sys.exit(1)
+if __name__ == "__main__":
+    args = build_arg_parser().parse_args()
+    rubrik = create_polaris_client(args)
 
 ### Get GCP SA
 # pp.pprint(rubrik.get_account_gcp_default_sa())
@@ -120,13 +125,6 @@ except Exception as err:
 # pp.pprint(rubrik.get_accounts_gcp())
 # pp.pprint(rubrik.get_accounts_azure())
 # pp.pprint(rubrik.update_account_aws())
-
-### Event interface
-# end_time = datetime.datetime.now().isoformat()
-# start_time = (datetime.datetime.now() - datetime.timedelta(days=1)).isoformat()
-# todays_failed_events = rubrik.get_event_series_list(cluster_ids=['603109f2-eb30-4da8-9389-911d66abb524'], status=["Failure"], start_time=start_time, end_time=end_time)
-# todays_failed_events = rubrik.get_event_series_list(start_time=start_time, end_time=end_time)
-# print("Returned events : {}".format(len(todays_failed_events)))
 
 ### Basic event summaries
 # summary = {}

--- a/sample/todays_failed_events.py
+++ b/sample/todays_failed_events.py
@@ -1,0 +1,45 @@
+#! /usr/bin/env python3
+import datetime
+import os
+import pprint
+import sys
+
+# Add the directory containing `polaris_client.py` to sys.path
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+from polaris_client import build_arg_parser, create_polaris_client
+
+pp = pprint.PrettyPrinter(indent=4)
+
+
+def get_todays_failed_events(client, cluster_ids=None):
+    """Fetch and return today's failed events for the passed clusters."""
+    end_time = datetime.datetime.now().isoformat()
+    start_time = (datetime.datetime.now() - datetime.timedelta(
+        days=1)).isoformat()
+    return rubrik.get_event_series_list(cluster_ids=cluster_ids,
+                                        status=["FAILURE"],
+                                        start_time=start_time,
+                                        end_time=end_time)
+
+
+if __name__ == "__main__":
+    parser = build_arg_parser()
+    parser.add_argument('-f', '--first', dest='first',
+                        help="Number of clusters to get events for",
+                        default=1, type=int)
+    args = parser.parse_args()
+    rubrik = create_polaris_client(args)
+
+    clusters = rubrik.list_clusters(first=args.first)
+    ids = [cluster['id'] for cluster in clusters]
+    if len(ids) == 0:
+        print("No clusters found.")
+        sys.exit(0)
+    # workaround for bug in list_clusters not honoring first=1
+    ids = ids[:args.first]
+    print("Found {} cluster(s): {}".format(len(ids), ids))
+    events = get_todays_failed_events(rubrik, ids)
+    print("Returned events : {}".format(len(events)))
+    if len(events) > 0:
+        print("Event 0 : {}".format(events[0]))


### PR DESCRIPTION
-  get_event_series_list() was out of date - this PR updates it to conform with the latest gql schema.
- sample/todays_failed_events.py is a new sample app that demonstrates how to use get_event_series_list() 
  with an example that retrieves failed events on given clusters. If no clusters are given, the sample app
  automatically selects the first cluster in the list of clusters.
- sample/polaris_client.py was modified so that it can be imported from other sample apps. Its functionality is untouched.