### PR TITLE
Pass the eks version when approving a bundle

### DIFF
--- a/sample/pcr-aws/pcr.py
+++ b/sample/pcr-aws/pcr.py
@@ -357,7 +357,10 @@ logging.debug(json.dumps(exoTaskImageBundle, indent=2))
 variables = {
   "input": {
     "approvalStatus": "ACCEPTED",
-    "bundleVersion": "{}".format(exoTaskImageBundle['data']['exotaskImageBundle']['bundleVersion'])
+    "bundleVersion": "{}".format(exoTaskImageBundle['data']['exotaskImageBundle']['bundleVersion']),
+    "bundleMetadata": {
+        "eksVersion": args.eksVersion
+    }
   }
 }
 SetBundleApprovalStatus = rubrik._query_raw(raw_query='mutation SetBundleApprovalStatus($input: SetBundleApprovalStatusInput!) {setBundleApprovalStatus(input: $input)}',


### PR DESCRIPTION
There is one small bug in the pcr script. We need the EKS version when launching exocompute cluster. We are making this field mandatory for all customers. Making the change here as well since most of the customer use this script for PCR setup.

Doc: https://rubrikinc.github.io/rubrik-api-documentation/use-cases/cloud-native-private-container-registry/