### PR TITLE
Use env-aware Docker API client in pcr-aws script

### DIFF
--- a/sample/pcr-aws/pcr.py
+++ b/sample/pcr-aws/pcr.py
@@ -163,7 +163,7 @@ rscEcrClient = rscEcrSession.client('ecr', region_name=region)
 # Setup Docker client
 
 dockerClient = docker.from_env()
-docker_api_client = docker.APIClient(base_url='unix://var/run/docker.sock')
+docker_api_client = dockerClient.api
 
 # Login to RSC ECR
 # Requires that the RSC setPrivateContainerRegistry GraphQL mutation has been run to set the registry URL in RSC.


### PR DESCRIPTION
## Summary

### What?
- Stop constructing a separate low-level Docker client with a hard-coded Docker socket.
- Use `dockerClient.api` from the existing env-aware `docker.from_env()` client instead.

### Why?
- The script currently assumes `/var/run/docker.sock`, which breaks in environments where:
  - Docker is exposed via `DOCKER_HOST` / a remote daemon, or
  - The local Docker socket is not mounted.
- Reusing the env-aware client preserves behavior on hosts with local Docker and allows the script to work with standard Docker configuration.

### How?
- Replace:
  - `docker_api_client = docker.APIClient(base_url='unix://var/run/docker.sock')`
- With:
  - `dockerClient = docker.from_env()`
  - `docker_api_client = dockerClient.api`
- All existing `login`, `pull`, `tag`, and `push` call sites remain unchanged and now share a single, consistently configured client.

## Test Plan
- Ran script E2E test after change source to forked branch
```
python3 -m jedi.tools.sdt_runner --test_target //jedi/e2e/cloudnative/paas_staging:pcr_aws_image_migration_script_test --allow_unused_byor --no_confirm_sdt_orders --allow_multiple_byor --no_reuse_sdt_order --release_bodega_resource --bodega_fulfilled_items '{"_item_1": {"spark_instance": {"context": "jenkins-025", "account": "jedi-test-pcr-a-bodega-gq1ml", "username": "scaledata@rubrik.com", "password": "***", "dns": "bodega.jenkins-025.my.rubrik-lab.com", "role": "00000000-0000-0000-0000-000000000000"}, "item_type": "polaris_gcp"}}' -- --is_aws_immutability_enabled 0 --cp polaris --log-cli-level=DEBUG --disable-pytest-warnings -m polaris_feature_pipeline -o custom_triage=1 --polaris_env_vars USE_PIPELINE_ENV_FOR_UFF=true,DEPLOYMENT_IS_FOR_PIPELINE_RUN=true
```
