### PR TITLE
Use pipenv instead of legacy setuptools

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -24,9 +24,9 @@ jobs:
       - name: install CI dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pipenv pylint mypy
-      - name: install SDK
-        run: pipenv install -e . --skip-lock
+          pip install pipenv
+      - name: install SDK and dev dependencies
+        run: pipenv install --dev --skip-lock
       - name: lint - pylint
         # Disabled linters:
         # R0801 - duplicate-code
@@ -78,7 +78,7 @@ jobs:
         # W1510 - subprocess-run-check
         # W1514 - unspecified-encoding
         run: |
-          python -m pylint $(git ls-files '*.py') \
+          pipenv run pylint $(git ls-files '*.py') \
             -d R0801 \
             -d R0913 \
             -d R0914 \
@@ -130,8 +130,6 @@ jobs:
             -d W1514
         shell: bash
       - name: lint - mypy
-        run: python -m mypy --strict $(git ls-files '*.py') || true
+        run: pipenv run mypy --strict $(git ls-files '*.py') || true
       - name: unit tests
-        run: |
-          pipenv install --skip-lock pytest requests_mock
-          pipenv run pytest tests/rubrik_polaris
+        run: pipenv run pytest tests/rubrik_polaris

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -24,9 +24,9 @@ jobs:
       - name: install CI dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pylint mypy
+          pip install pipenv pylint mypy
       - name: install SDK
-        run: python setup.py install
+        run: pipenv install -e . --skip-lock
       - name: lint - pylint
         # Disabled linters:
         # R0801 - duplicate-code
@@ -133,5 +133,5 @@ jobs:
         run: python -m mypy --strict $(git ls-files '*.py') || true
       - name: unit tests
         run: |
-          pip install -r tests/requirements.txt
-          pytest tests/rubrik_polaris
+          pipenv install --skip-lock pytest requests_mock
+          pipenv run pytest tests/rubrik_polaris

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include README.md
+recursive-include rubrik_polaris/common/graphql *.graphql
+

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,17 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+"rubrik-polaris-sdk" = {editable = true, path = "."}
+
+[dev-packages]
+pylint = "*"
+mypy = "*"
+pytest = "*"
+requests-mock = "*"
+
+[requires]
+python_version = "3.8"
+

--- a/rubrik_polaris/rubrik_polaris.py
+++ b/rubrik_polaris/rubrik_polaris.py
@@ -123,7 +123,7 @@ class PolarisClient:
 
         # Set base variables
         self._kwargs = kwargs
-        self._data_path = "{}/graphql/".format(os.path.dirname(os.path.realpath(__file__)))
+        self._data_path = "{}/common/graphql/".format(os.path.dirname(os.path.realpath(__file__)))
 
         # Switch off SSL checks if needed
         if 'insecure' in self._kwargs and self._kwargs['insecure']:

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 from datetime import datetime
-from glob import glob
 
 import setuptools
 

--- a/setup.py
+++ b/setup.py
@@ -53,9 +53,9 @@ setuptools.setup(
         'httplib2 <1dev, >=0.15.0'
     ],
     include_package_data=True,
-    data_files = [
-        ('rubrik_polaris/graphql', glob('rubrik_polaris/common/graphql/*'))
-    ],
+    package_data={
+        'rubrik_polaris': ['common/graphql/*.graphql'],
+    },
     tests_require=[
         'pytest'
     ],


### PR DESCRIPTION
setuptools causes all kinds of dependency issues as it is the old deprecated methods. With this change we switch to using pipenv instead.